### PR TITLE
v0.0.2 -- (hotfix/pkg): `jest@"23-24"` -> `jest@"23 - 24"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Explicitly import [Jest](https://github.com/facebook/jest) globals.
 
 `npm i -D jest-without-globals`
 
+_(note that `jest` is a peer dependency)_
+
 ## Usage
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ The source code is currently shorter than this README, so [take a look under the
 
 ## Credits
 
-Some inspiration for this came from [this workaround](https://github.com/facebook/jest/pull/7571#issuecomment-498634094) to avoid globals, which I had been using in projects previously.
-I wanted a package I could re-use in all my projects' tests instead of constantly having to create a helper file and map its name, and so `jest-without-globals` was born.
+Some inspiration came from [this workaround](https://github.com/facebook/jest/pull/7571#issuecomment-498634094) to avoid globals, which I had been using in projects previously.
+I wanted a package I could re-use in all my projects' tests instead of constantly having to create a helper file and map its name, and so `jest-without-globals` was born!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-without-globals",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-without-globals",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Explicitly import Jest globals",
   "main": "dist/index.js",
   "module": "dist/jest-without-globals.esm.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "changelog": "changelog-maker"
   },
   "peerDependencies": {
-    "jest": "23-24"
+    "jest": "23 - 24"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
- apparently the space is necessary or else it won't recognize ANY versions
  - probably bc "23-24" could be the name of a pre-release, though I don't believe that's valid SemVer

Also adds some _very_ minor docs changes and publish commit